### PR TITLE
replace parent with is_initial

### DIFF
--- a/datafusion/expr/src/logical_plan/invariants.rs
+++ b/datafusion/expr/src/logical_plan/invariants.rs
@@ -242,7 +242,7 @@ pub fn check_subquery_expr(
             | LogicalPlan::TableScan(_)
             | LogicalPlan::Window(_)
             | LogicalPlan::Aggregate(_)
-            | LogicalPlan::Join(_) 
+            | LogicalPlan::Join(_)
             | LogicalPlan::DependentJoin(_) => Ok(()),
             _ => plan_err!(
                 "In/Exist subquery can only be used in \


### PR DESCRIPTION
`parent` is only used to indicate whether it is the first time creating a `DependentJoinDecorrelator`